### PR TITLE
Potential fix for code scanning alert no. 95: Flask app is run in debug mode

### DIFF
--- a/scripts/mock_api_server.py
+++ b/scripts/mock_api_server.py
@@ -233,4 +233,4 @@ if __name__ == '__main__':
     print("📊 Health Check: http://localhost:5000/api/integrated/system/health")
     print("📝 Press Ctrl+C to stop the server")
     
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/95](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/95)

The primary fix is to remove `debug=True` from the `app.run()` call in scripts/mock_api_server.py, ensuring that the Flask server starts with debugging disabled. This prevents exposure of the interactive debugger on public interfaces.  
To preserve the ability to enable debug mode for development, you may instead use an environment variable or config flag, but the current code should **not** run debug mode by default.  
Only line 236 needs editing: remove the `debug=True` argument. No additional imports or significant code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
