### PR TITLE
Potential fix for code scanning alert no. 69: Uncontrolled data used in path expression

### DIFF
--- a/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
+++ b/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
@@ -214,7 +214,7 @@ class MCPServer:
             else:
                 # Directory listing
                 items = []
-                for item in full_path.iterdir():
+                for item in candidate_path.iterdir():
                     items.append({
                         "name": item.name,
                         "type": "directory" if item.is_dir() else "file",

--- a/core-services/link-ai-core/backend/services/mcp-server/main.py
+++ b/core-services/link-ai-core/backend/services/mcp-server/main.py
@@ -28,6 +28,8 @@ class MCPTool(BaseModel):
     inputSchema: Dict[str, Any]
 
 class MCPServer:
+    ALLOWED_FILES_ROOT = Path("allowed_files").resolve()  # Adjust path to desired root directory
+    
     def __init__(self):
         self.resources: Dict[str, MCPResource] = {}
         self.tools: Dict[str, MCPTool] = {}
@@ -190,12 +192,17 @@ class MCPServer:
     async def read_file_resource(self, path: str) -> Dict[str, Any]:
         """Read file system resource"""
         try:
-            full_path = Path(path)
-            if not full_path.exists():
+            # Prevent path traversal by resolving against allowed root
+            # Remove leading slashes to avoid absolute path bypass
+            safe_rel_path = path.lstrip("/\\")
+            candidate_path = (self.ALLOWED_FILES_ROOT / safe_rel_path).resolve()
+            if not str(candidate_path).startswith(str(self.ALLOWED_FILES_ROOT)):
+                return {"error": "Access denied: file outside allowed directory"}
+            if not candidate_path.exists():
                 return {"error": f"File not found: {path}"}
             
-            if full_path.is_file():
-                async with aiofiles.open(full_path, 'r', encoding='utf-8') as f:
+            if candidate_path.is_file():
+                async with aiofiles.open(candidate_path, 'r', encoding='utf-8') as f:
                     content = await f.read()
                 return {
                     "contents": [{
@@ -207,7 +214,7 @@ class MCPServer:
             else:
                 # Directory listing
                 items = []
-                for item in full_path.iterdir():
+                for item in candidate_path.iterdir():
                     items.append({
                         "name": item.name,
                         "type": "directory" if item.is_dir() else "file",


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/69](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/69)

To fix the uncontrolled path usage, we must restrict user-supplied file paths so that only files within an intended root directory are accessible. This involves:

- Defining a root directory that should contain all accessible files (e.g., `ALLOWED_FILES_ROOT`).
- Constructing the file path by joining the root with the user-supplied path, **then normalizing it** using `os.path.normpath` or `Path.resolve()`.
- Ensuring that the normalized/resolved path is a child of the root directory, rejecting requests that escape the directory (e.g., via ".." or absolute paths).
- Applying this check in the `read_file_resource` method at the place where the `full_path` is created and before any file IO occurs.
- Optionally, handling overly long paths or invalid path segments.

Required changes:
- Define an `ALLOWED_FILES_ROOT` for files (e.g., at the top of the MCPServer class).
- In `read_file_resource`, join this root with the provided `path`, normalize, and check that the result is still under the root.
- If the check fails, return an error.
- Import `os` if needed (already imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
