### PR TITLE
Potential fix for code scanning alert no. 108: Uncontrolled data used in path expression

### DIFF
--- a/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
+++ b/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
@@ -324,10 +324,17 @@ class MCPServer:
         
         try:
             # Restrict file access to within ROOT_DIR
+            if not path or not isinstance(path, str):
+                return {"error": "Invalid or missing path argument."}
             user_path = Path(path)
+            if user_path.is_absolute():
+                return {"error": "Absolute paths are not allowed."}
             full_path = (ROOT_DIR / user_path).resolve()
             root_resolved = ROOT_DIR.resolve()
-            if not str(full_path).startswith(str(root_resolved)):
+            try:
+                # Ensure full_path is strictly within root_resolved
+                full_path.relative_to(root_resolved)
+            except ValueError:
                 return {"error": "Access to the requested path is not allowed."}
             
             # Ensure directory exists


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/108](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/108)

The best way to fix this vulnerability is to adopt a robust path validation that ensures the requested path is within the allowed root directory, is always treated as relative, and cannot escape via parent directory traversal or absolute pathing. The preferred pattern is: resolve both `ROOT_DIR` and the constructed full path (combining `ROOT_DIR` and the user-provided path), ensure the user path is not absolute, and use `Path.relative_to()` to test that the final path remains under `ROOT_DIR`. This strategy matches the one already present in the `tool_read_file` method, so should be applied in `tool_write_file` for consistency. Specifically:

- On lines 321–332:
  - Explicitly reject absolute paths: if `Path(path).is_absolute()` return error.
  - After combining and resolving the full path, use `full_path.relative_to(root_resolved)` in a try-except block to ensure strict containment within the root.
  - Only proceed if validation passes.
- Contextual changes: do not use the string `startswith` check.

Required resources:
- Existing imports are sufficient (using `Path`).
- Method code edits, with exception handling for `ValueError` on containment checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
