### PR TITLE
Potential fix for code scanning alert no. 173: Uncontrolled data used in path expression

### DIFF
--- a/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
+++ b/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
@@ -344,9 +344,12 @@ class MCPServer:
             # Restrict file access to within ROOT_DIR
             if not path or not isinstance(path, str):
                 return {"error": "Invalid or missing path argument."}
-            user_path = Path(path)
-            if user_path.is_absolute():
-                return {"error": "Absolute paths are not allowed."}
+            # Normalize user input to prevent traversal attacks
+            normalized_user_path_str = os.path.normpath(path)
+            # Prevent absolute/escaped paths after normalization
+            if normalized_user_path_str.startswith(os.sep) or normalized_user_path_str.startswith(".."):
+                return {"error": "Path traversal or absolute paths are not allowed."}
+            user_path = Path(normalized_user_path_str)
             full_path = (ROOT_DIR / user_path).resolve()
             root_resolved = ROOT_DIR.resolve()
             try:


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/173](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/173)

To robustly prevent path traversal and denial-of-service attacks via user-controlled `path` parameters, paths should be normalized before they are joined with the root directory. This can be done using `os.path.normpath(str(user_path))` or, with pathlib, manipulating the components directly. After normalization, the resulting path should be checked to ensure it resides within the allowed root (`ROOT_DIR`). Additionally, the existing check using `.relative_to()` should remain to protect against symlink/edge-case abuses. All manipulation should be done using string representations for best compatibility and clarity.

**Best fix:**  
- Before combining `ROOT_DIR` and `user_path`, normalize the user-supplied path using `os.path.normpath`.
- Combine the normalized path with `ROOT_DIR`, resolve, and then check for containment in root.
- Optionally, re-check that the normalized path does not attempt to move outside the root (e.g. doesn't start with `..` or `/` after normalization).

**Changes needed:**  
- Edit the `tool_write_file` method (lines around 347-350):  
  - Normalize `path` after the initial type/absence check.
  - Replace construction of `user_path` with one using the normalized string.
  - Continue to reject absolute paths.
- Imports: add `import os` (already present as `import os` on line 7).
- No additional dependencies needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
