### PR TITLE
Potential fix for code scanning alert no. 188: Uncontrolled data used in path expression

### DIFF
--- a/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
+++ b/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
@@ -196,33 +196,24 @@ class MCPServer:
     async def read_file_resource(self, path: str) -> Dict[str, Any]:
         """Read file system resource (strict sanitized access within ROOT_DIR)"""
         try:
-            # Normalize incoming path to avoid directory traversal
-            normalized_path = os.path.normpath(path)
-            # Reject absolute paths and those which try to escape via '..'
-            if (
-                os.path.isabs(normalized_path) or
-                normalized_path.startswith("..") or
-                any(part == ".." for part in normalized_path.split(os.sep)) or
-                normalized_path == ""    # no empty path allowed
-            ):
-                return {"error": "Access denied"}
-            # At this point, normalized_path is safe to join
-            candidate_path = (ROOT_DIR / normalized_path)
-            # Now resolve to its true location
-            full_path = candidate_path.resolve()
-            # Ensure containment using Path.relative_to, which raises ValueError if escaping
+            # Remove any leading slashes, so user cannot supply absolute paths
+            safe_path = path.lstrip("/\\")
+            # Join with root and resolve
+            candidate_path = (ROOT_DIR / safe_path)
             try:
+                full_path = candidate_path.resolve(strict=False)
+                # Ensure containment using Path.relative_to, which raises ValueError if escaping
                 full_path.relative_to(ROOT_DIR.resolve())
-            except ValueError:
+            except Exception:
                 return {"error": "Access denied"}
             if not full_path.exists():
-                return {"error": f"File not found: {normalized_path}"}
+                return {"error": f"File not found: {safe_path}"}
             if full_path.is_file():
                 async with aiofiles.open(full_path, 'r', encoding='utf-8') as f:
                     content = await f.read()
                 return {
                     "contents": [{
-                        "uri": f"file://{normalized_path}",
+                        "uri": f"file://{safe_path}",
                         "mimeType": "text/plain",
                         "text": content
                     }]
@@ -238,7 +229,7 @@ class MCPServer:
                     })
                 return {
                     "contents": [{
-                        "uri": f"file://{path}",
+                        "uri": f"file://{safe_path}",
                         "mimeType": "application/json",
                         "text": json.dumps(items, indent=2)
                     }]


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/188](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/188)

The best way to fully fix this "uncontrolled data used in path expression" is to enhance and clarify our path validation, ensuring that user-supplied paths CANNOT be interpreted as escaping, traversing, or otherwise breaking out of the allowed root. 

**How to fix generally:**  
- Normalize and resolve the user path _after_ joining with the root directory.
- Before using the filesystem (and passing path to open/iterdir), perform a robust check that the fully resolved path is a child (descendant or equal) of the root directory's resolved path, or else return an error.
- Never pass unsanitized/unresolved user-influenced paths to the filesystem; always check first.
- Synchronously refuse access on any invalid or suspicious request.

**Specifically for this code:**  
- Replace the current normalization and parent check logic with the canonical approach: first join the user-provided (or normalized) path to the trusted root, then _resolve_ it, then check `.relative_to(ROOT_DIR.resolve())` before ever touching the filesystem.
- Optionally also reject any user-provided paths that are absolute before join.
- Limit supported path schemes to those you intend (already done).
- Ensure no other write or read paths exist that lack robust validation.

**What to change:**  
- In the `read_file_resource` method in `chonost-unified/backend/mcp/backend/services/mcp-server/main.py`, specifically lines 197-247:
  - Move all checks to _after_ the joined path has been resolved.
  - Remove redundant pre-checks (`isabs`, `startswith("..")`, etc.), since `.relative_to()` and post-join normalization will catch escapes.
  - Return an error *before* touching the filesystem (i.e. before checking `exists()`, `is_file()`, etc.) if containment is violated.
  - Be explicit about which lines do the join/resolve/check.

**Imports:**  
- No new imports needed. All required modules (`os`, `pathlib.Path`) are already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
