### PR TITLE
Potential fix for code scanning alert no. 194: Uncontrolled data used in path expression

### DIFF
--- a/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
+++ b/chonost-unified/backend/mcp/backend/services/mcp-server/main.py
@@ -229,14 +229,22 @@ class MCPServer:
                 # Directory listing
                 items = []
                 for item in full_path.iterdir():
+                    # Construct a safe, root-relative path for item URI
+                    try:
+                        rel_item_path = item.resolve(strict=True).relative_to(ROOT_DIR.resolve()).as_posix()
+                    except Exception:
+                        # Skip items that escape the root (shouldn't happen due to earlier checks)
+                        continue
                     items.append({
                         "name": item.name,
                         "type": "directory" if item.is_dir() else "file",
-                        "uri": f"file://{item}"
+                        "uri": f"file://{rel_item_path}"
                     })
+                # Construct root-relative path for the directory itself
+                safe_rel_path = full_path.relative_to(ROOT_DIR.resolve()).as_posix()
                 return {
                     "contents": [{
-                        "uri": f"file://{safe_path}",
+                        "uri": f"file://{safe_rel_path}",
                         "mimeType": "application/json",
                         "text": json.dumps(items, indent=2)
                     }]


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/194](https://github.com/billlzzz10/Chonost-manifest-os/security/code-scanning/194)

To fix the issue, update the code paths that emit URIs in the directory listing to generate them as relative paths under the `ROOT_DIR`, sanitized as in the file read case (`safe_rel_path`). This avoids leaking any absolute file paths or unintended directory structures. Specifically:

- In the directory listing (`else:` block in `read_file_resource`), for each entry in the directory (`item`), construct its path relative to `ROOT_DIR.resolve()`, exactly as done for files.
- Set the `uri` fields in the response to be of the form `file://<relative_path>` where `<relative_path>` is the path under root.
- Fix the reference to `safe_path` (which is undefined) in directory listing; instead, use the same normalized, relative path used above.
- Ensure that all paths returned to the user are always relative to the root, never absolute or external.

No changes to imports are needed, as `Path` and related utilities are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
